### PR TITLE
Add external auth modules

### DIFF
--- a/auth-api/build.gradle.kts
+++ b/auth-api/build.gradle.kts
@@ -16,6 +16,7 @@ repositories {
 
 dependencies {
     api("org.springframework.cloud:spring-cloud-starter-openfeign")
+    api(project(":auth-core"))
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 }

--- a/auth-api/build.gradle.kts
+++ b/auth-api/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    `java-library`
+    id("org.springframework.boot") version "3.5.3" apply false
+    id("io.spring.dependency-management") version "1.1.7"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api("org.springframework.cloud:spring-cloud-starter-openfeign")
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+}
+

--- a/auth-api/src/main/java/com/otr/authapi/AuthApiConfiguration.java
+++ b/auth-api/src/main/java/com/otr/authapi/AuthApiConfiguration.java
@@ -1,0 +1,19 @@
+package com.otr.authapi;
+
+import feign.Retryer;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ImportAutoConfiguration(FeignAutoConfiguration.class)
+public class AuthApiConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Retryer feignRetryer() {
+        return new Retryer.Default();
+    }
+}

--- a/auth-api/src/main/java/com/otr/authapi/AuthApiConfiguration.java
+++ b/auth-api/src/main/java/com/otr/authapi/AuthApiConfiguration.java
@@ -3,11 +3,16 @@ package com.otr.authapi;
 import feign.Retryer;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import com.otr.authcore.AuthApi;
+import com.otr.authapi.FeignAuthApi;
+import com.otr.authapi.AuthClient;
 
 @Configuration
+@EnableConfigurationProperties(AuthApiProperties.class)
 @ImportAutoConfiguration(FeignAutoConfiguration.class)
 public class AuthApiConfiguration {
 
@@ -15,5 +20,11 @@ public class AuthApiConfiguration {
     @ConditionalOnMissingBean
     public Retryer feignRetryer() {
         return new Retryer.Default();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AuthApi feignAuthApi(AuthClient client) {
+        return new FeignAuthApi(client);
     }
 }

--- a/auth-api/src/main/java/com/otr/authapi/AuthApiProperties.java
+++ b/auth-api/src/main/java/com/otr/authapi/AuthApiProperties.java
@@ -1,0 +1,17 @@
+package com.otr.authapi;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "auth.api")
+public class AuthApiProperties {
+    /** Base URL of external auth service */
+    private String url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/auth-api/src/main/java/com/otr/authapi/AuthApiProperties.java
+++ b/auth-api/src/main/java/com/otr/authapi/AuthApiProperties.java
@@ -1,17 +1,11 @@
 package com.otr.authapi;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.Data;
 
 @ConfigurationProperties(prefix = "auth.api")
+@Data
 public class AuthApiProperties {
     /** Base URL of external auth service */
     private String url;
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
 }

--- a/auth-api/src/main/java/com/otr/authapi/AuthClient.java
+++ b/auth-api/src/main/java/com/otr/authapi/AuthClient.java
@@ -1,0 +1,12 @@
+package com.otr.authapi;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "ext-auth", url = "${auth.api.url}")
+public interface AuthClient {
+
+    @GetMapping("/auth")
+    ExternalUserDto authenticate(@RequestHeader("user") String user);
+}

--- a/auth-api/src/main/java/com/otr/authapi/ExternalUserDto.java
+++ b/auth-api/src/main/java/com/otr/authapi/ExternalUserDto.java
@@ -1,0 +1,42 @@
+package com.otr.authapi;
+
+import java.util.List;
+
+public class ExternalUserDto {
+    private String username;
+    private String organization;
+    private List<String> documentTypes;
+
+    public ExternalUserDto() {
+    }
+
+    public ExternalUserDto(String username, String organization, List<String> documentTypes) {
+        this.username = username;
+        this.organization = organization;
+        this.documentTypes = documentTypes;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(String organization) {
+        this.organization = organization;
+    }
+
+    public List<String> getDocumentTypes() {
+        return documentTypes;
+    }
+
+    public void setDocumentTypes(List<String> documentTypes) {
+        this.documentTypes = documentTypes;
+    }
+}

--- a/auth-api/src/main/java/com/otr/authapi/ExternalUserDto.java
+++ b/auth-api/src/main/java/com/otr/authapi/ExternalUserDto.java
@@ -1,42 +1,16 @@
 package com.otr.authapi;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ExternalUserDto {
     private String username;
     private String organization;
     private List<String> documentTypes;
-
-    public ExternalUserDto() {
-    }
-
-    public ExternalUserDto(String username, String organization, List<String> documentTypes) {
-        this.username = username;
-        this.organization = organization;
-        this.documentTypes = documentTypes;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getOrganization() {
-        return organization;
-    }
-
-    public void setOrganization(String organization) {
-        this.organization = organization;
-    }
-
-    public List<String> getDocumentTypes() {
-        return documentTypes;
-    }
-
-    public void setDocumentTypes(List<String> documentTypes) {
-        this.documentTypes = documentTypes;
-    }
 }

--- a/auth-api/src/main/java/com/otr/authapi/FeignAuthApi.java
+++ b/auth-api/src/main/java/com/otr/authapi/FeignAuthApi.java
@@ -1,0 +1,15 @@
+package com.otr.authapi;
+
+import com.otr.authcore.AuthApi;
+import com.otr.authcore.AuthInfo;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+class FeignAuthApi implements AuthApi {
+    private final AuthClient client;
+    @Override
+    public AuthInfo authenticate(String header) {
+        ExternalUserDto dto = client.authenticate(header);
+        return new AuthInfo(dto.getUsername(), dto.getOrganization(), dto.getDocumentTypes());
+    }
+}

--- a/auth-api/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auth-api/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.otr.authapi.AuthApiConfiguration
+

--- a/auth-core/build.gradle.kts
+++ b/auth-core/build.gradle.kts
@@ -15,7 +15,6 @@ repositories {
 }
 
 dependencies {
-    api(project(":auth-api"))
     api("org.springframework.boot:spring-boot-starter-security")
     api("org.springframework.boot:spring-boot-starter-web")
     api("com.github.ben-manes.caffeine:caffeine")

--- a/auth-core/build.gradle.kts
+++ b/auth-core/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    `java-library`
+    id("org.springframework.boot") version "3.5.3" apply false
+    id("io.spring.dependency-management") version "1.1.7"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api(project(":auth-api"))
+    api("org.springframework.boot:spring-boot-starter-security")
+    api("org.springframework.boot:spring-boot-starter-web")
+    api("com.github.ben-manes.caffeine:caffeine")
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+}
+

--- a/auth-core/src/main/java/com/otr/authcore/AuthApi.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthApi.java
@@ -1,0 +1,13 @@
+package com.otr.authcore;
+
+/**
+ * Interface for external authentication API.
+ */
+public interface AuthApi {
+    /**
+     * Authenticate user using provided header value.
+     * @param header header value
+     * @return authenticated user info or null if authentication failed
+     */
+    AuthInfo authenticate(String header);
+}

--- a/auth-core/src/main/java/com/otr/authcore/AuthAutoConfiguration.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthAutoConfiguration.java
@@ -1,0 +1,44 @@
+package com.otr.authcore;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableConfigurationProperties(AuthProperties.class)
+@ImportAutoConfiguration(com.otr.authapi.AuthApiConfiguration.class)
+public class AuthAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ExternalAuthProvider externalAuthProvider(AuthService service) {
+        return new ExternalAuthProvider(service);
+    }
+
+    @Bean(name = "externalAuthManager")
+    @ConditionalOnMissingBean(name = "externalAuthManager")
+    public AuthenticationManager authenticationManager(ExternalAuthProvider provider) {
+        return new ProviderManager(provider);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AuthFilter authFilter(AuthProperties properties, AuthenticationManager externalAuthManager) {
+        return new AuthFilter(properties, externalAuthManager);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "externalAuthFilterChain")
+    public SecurityFilterChain externalAuthFilterChain(HttpSecurity http, AuthFilter authFilter, ExternalAuthProvider provider) throws Exception {
+        http.addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class)
+                .authenticationProvider(provider);
+        return http.build();
+    }
+}

--- a/auth-core/src/main/java/com/otr/authcore/AuthAutoConfiguration.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthAutoConfiguration.java
@@ -1,6 +1,5 @@
 package com.otr.authcore;
 
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -13,9 +12,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableConfigurationProperties(AuthProperties.class)
-@ImportAutoConfiguration(com.otr.authapi.AuthApiConfiguration.class)
 public class AuthAutoConfiguration {
 
+    @Bean
+    @ConditionalOnMissingBean
+    public AuthService authService(AuthApi api, AuthProperties properties) {
+        return new AuthService(api, properties);
+    }
     @Bean
     @ConditionalOnMissingBean
     public ExternalAuthProvider externalAuthProvider(AuthService service) {

--- a/auth-core/src/main/java/com/otr/authcore/AuthFilter.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthFilter.java
@@ -1,0 +1,43 @@
+package com.otr.authcore;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class AuthFilter extends OncePerRequestFilter {
+
+    private final AuthProperties properties;
+    private final AuthenticationManager authenticationManager;
+
+    public AuthFilter(AuthProperties properties, AuthenticationManager authenticationManager) {
+        this.properties = properties;
+        this.authenticationManager = authenticationManager;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (!Collections.list(request.getHeaderNames()).contains(properties.getHeader())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String headerValue = request.getHeader(properties.getHeader());
+        HeaderAuthToken token = new HeaderAuthToken(headerValue);
+        try {
+            Authentication auth = authenticationManager.authenticate(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException ex) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+        }
+    }
+}

--- a/auth-core/src/main/java/com/otr/authcore/AuthInfo.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthInfo.java
@@ -1,0 +1,27 @@
+package com.otr.authcore;
+
+import java.util.List;
+
+public class AuthInfo {
+    private final String username;
+    private final String organization;
+    private final List<String> documentTypes;
+
+    public AuthInfo(String username, String organization, List<String> documentTypes) {
+        this.username = username;
+        this.organization = organization;
+        this.documentTypes = documentTypes;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getOrganization() {
+        return organization;
+    }
+
+    public List<String> getDocumentTypes() {
+        return documentTypes;
+    }
+}

--- a/auth-core/src/main/java/com/otr/authcore/AuthInfo.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthInfo.java
@@ -1,27 +1,14 @@
 package com.otr.authcore;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.util.List;
 
+@Getter
+@AllArgsConstructor
 public class AuthInfo {
     private final String username;
     private final String organization;
     private final List<String> documentTypes;
-
-    public AuthInfo(String username, String organization, List<String> documentTypes) {
-        this.username = username;
-        this.organization = organization;
-        this.documentTypes = documentTypes;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public String getOrganization() {
-        return organization;
-    }
-
-    public List<String> getDocumentTypes() {
-        return documentTypes;
-    }
 }

--- a/auth-core/src/main/java/com/otr/authcore/AuthProperties.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthProperties.java
@@ -1,0 +1,29 @@
+package com.otr.authcore;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "auth")
+public class AuthProperties {
+    /** Header name */
+    private String header = "X-Auth";
+    /** Cache TTL */
+    private Duration cacheTtl = Duration.ofMinutes(10);
+
+    public String getHeader() {
+        return header;
+    }
+
+    public void setHeader(String header) {
+        this.header = header;
+    }
+
+    public Duration getCacheTtl() {
+        return cacheTtl;
+    }
+
+    public void setCacheTtl(Duration cacheTtl) {
+        this.cacheTtl = cacheTtl;
+    }
+}

--- a/auth-core/src/main/java/com/otr/authcore/AuthProperties.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthProperties.java
@@ -1,29 +1,15 @@
 package com.otr.authcore;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.Data;
 
 import java.time.Duration;
 
 @ConfigurationProperties(prefix = "auth")
+@Data
 public class AuthProperties {
     /** Header name */
     private String header = "X-Auth";
     /** Cache TTL */
     private Duration cacheTtl = Duration.ofMinutes(10);
-
-    public String getHeader() {
-        return header;
-    }
-
-    public void setHeader(String header) {
-        this.header = header;
-    }
-
-    public Duration getCacheTtl() {
-        return cacheTtl;
-    }
-
-    public void setCacheTtl(Duration cacheTtl) {
-        this.cacheTtl = cacheTtl;
-    }
 }

--- a/auth-core/src/main/java/com/otr/authcore/AuthService.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthService.java
@@ -2,18 +2,13 @@ package com.otr.authcore;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.otr.authapi.AuthClient;
-import com.otr.authapi.ExternalUserDto;
-import org.springframework.stereotype.Service;
 
-
-@Service
 public class AuthService {
 
-    private final AuthClient client;
+    private final AuthApi client;
     private final Cache<String, AuthInfo> cache;
 
-    public AuthService(AuthClient client, AuthProperties properties) {
+    public AuthService(AuthApi client, AuthProperties properties) {
         this.client = client;
         this.cache = Caffeine.newBuilder()
                 .expireAfterWrite(properties.getCacheTtl())
@@ -25,7 +20,6 @@ public class AuthService {
     }
 
     private AuthInfo load(String header) {
-        ExternalUserDto dto = client.authenticate(header);
-        return new AuthInfo(dto.getUsername(), dto.getOrganization(), dto.getDocumentTypes());
+        return client.authenticate(header);
     }
 }

--- a/auth-core/src/main/java/com/otr/authcore/AuthService.java
+++ b/auth-core/src/main/java/com/otr/authcore/AuthService.java
@@ -1,0 +1,31 @@
+package com.otr.authcore;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.otr.authapi.AuthClient;
+import com.otr.authapi.ExternalUserDto;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class AuthService {
+
+    private final AuthClient client;
+    private final Cache<String, AuthInfo> cache;
+
+    public AuthService(AuthClient client, AuthProperties properties) {
+        this.client = client;
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(properties.getCacheTtl())
+                .build();
+    }
+
+    public AuthInfo authenticate(String headerValue) {
+        return cache.get(headerValue, this::load);
+    }
+
+    private AuthInfo load(String header) {
+        ExternalUserDto dto = client.authenticate(header);
+        return new AuthInfo(dto.getUsername(), dto.getOrganization(), dto.getDocumentTypes());
+    }
+}

--- a/auth-core/src/main/java/com/otr/authcore/ExternalAuthProvider.java
+++ b/auth-core/src/main/java/com/otr/authcore/ExternalAuthProvider.java
@@ -1,0 +1,36 @@
+package com.otr.authcore;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+/**
+ * Spring Security AuthenticationProvider that delegates to AuthService.
+ */
+public class ExternalAuthProvider implements AuthenticationProvider {
+
+    private final AuthService authService;
+
+    public ExternalAuthProvider(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String header = (String) authentication.getPrincipal();
+        AuthInfo info = authService.authenticate(header);
+        if (info == null) {
+            throw new BadCredentialsException("Invalid authentication header");
+        }
+        AbstractAuthenticationToken result = new ExternalAuthToken(info);
+        result.setDetails(authentication.getDetails());
+        return result;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return HeaderAuthToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/auth-core/src/main/java/com/otr/authcore/ExternalAuthToken.java
+++ b/auth-core/src/main/java/com/otr/authcore/ExternalAuthToken.java
@@ -1,0 +1,29 @@
+package com.otr.authcore;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+public class ExternalAuthToken extends AbstractAuthenticationToken {
+
+    private final AuthInfo authInfo;
+
+    public ExternalAuthToken(AuthInfo authInfo) {
+        super(AuthorityUtils.createAuthorityList("ROLE_EXTERNAL"));
+        this.authInfo = authInfo;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return authInfo.getUsername();
+    }
+
+    public AuthInfo getAuthInfo() {
+        return authInfo;
+    }
+}

--- a/auth-core/src/main/java/com/otr/authcore/HeaderAuthToken.java
+++ b/auth-core/src/main/java/com/otr/authcore/HeaderAuthToken.java
@@ -1,0 +1,27 @@
+package com.otr.authcore;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+/**
+ * Authentication token carrying the raw header value.
+ */
+public class HeaderAuthToken extends AbstractAuthenticationToken {
+
+    private final String header;
+
+    public HeaderAuthToken(String header) {
+        super(null);
+        this.header = header;
+        setAuthenticated(false);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return header;
+    }
+}

--- a/auth-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auth-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.otr.authcore.AuthAutoConfiguration
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
+    implementation(project(":auth-core"))
+
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
     implementation(project(":auth-core"))
+    implementation(project(":auth-api"))
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,4 @@
 rootProject.name = "oss-security-pet"
+
+include("auth-core")
+include("auth-api")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=oss-security-pet
 poib.header=poib-remote-user
+auth.api.url=http://localhost:8081
 


### PR DESCRIPTION
## Summary
- create `auth-api` module with Feign client and properties
- create `auth-core` module with authentication filter, caching and auto‑configuration
- wire new modules into the existing application
- expose auth API URL in properties
- refactor authentication to use `AuthenticationProvider`

## Testing
- `./gradlew test` *(fails: unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687a09ae0690832c8db479b9fb9e7235